### PR TITLE
Implement ENV load over Eph Key P2P Messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+env.json

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ class API < Sinatra::Base
   use Jersey::API::EphKeyEnv
 end
 
+Jersey::API::EphKeyEnv.standalone!
+
 run Rack::Cascade.new([
   Jersey::API::EphKeyEnv,
   API
@@ -124,6 +126,35 @@ run Rack::URLMap.new(
   '/' => API
 )
 ```
+
+If you want to load your env before doing anything else,
+you can use the `EphKeyEnv::quit_after_run!` method.
+
+Because the EphKeyStore is a Sinatra Base class, it
+is simple to also run it as a standalone webserver.
+
+```ruby
+require 'jersey'
+Jersey.setup
+
+require 'jersey/eph_key_env'
+
+# wait on port for secrets
+Jersey::API::EphKeyEnv.port = ENV['PORT'] || 8000
+
+# use all the nice Jersey middleware
+Jersey::API::EphKeyEnv.standalone!
+
+# close up after secrets are loaded
+Jersey::API::EphKeyEnv.quit_after_load!
+
+# run with the detected server
+Jersey::API::EphKeyEnv.run!
+
+# resume processing
+puts ENV["FOO"]
+```
+
 
 #### `Jersey::HTTP::Errors`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ it easy to compose your own stack or use Jesery's compositions.
 
 ## Features
   - env-conf for easy ENV based configuration
+  - secure ENV loading mechanism
   - request context aware request logging
   - structured data loggers - json and logfmt
   - unified exception handling
@@ -95,6 +96,34 @@ Response:
 
 Unified, strucutred error handling. Notice how all we needed to do was raise `NotFound`
 and we get a 404 response code (in the server logs) and our error message as part of the JSON payload.
+
+### `Jersey::API::EphKeyEnv`
+
+Uses an ephemeral RSA key to expose endpoints that allow the server process
+to load an ENV using end-to-end encryption.
+
+#### Usage
+This is itself a Jersy API, which is a sinatra Base.
+
+That means you can mount it as a separate app in a `Rack::URLMap` or `Rack::Cascade`,
+or you can use it as a middleware.
+
+For example:
+```ruby
+class API < Sinatra::Base
+  use Jersey::API::EphKeyEnv
+end
+
+run Rack::Cascade.new([
+  Jersey::API::EphKeyEnv,
+  API
+])
+
+run Rack::URLMap.new(
+  '/eph/' => Jersey::API::EphKeyEnv,
+  '/' => API
+)
+```
 
 #### `Jersey::HTTP::Errors`
 

--- a/bin/eph-key-run
+++ b/bin/eph-key-run
@@ -1,0 +1,8 @@
+#! /usr/bin/env ruby
+
+require 'jersey'
+Jersey.setup
+require 'jersey/eph_key_env'
+puts ARGV
+Jersey::API::EphKeyEnv.one_time_load!(port: ENV['EPH_PORT'] || 80)
+exec("sh", "-c", "#{ARGV.join(" ").gsub("\\","\\\\")}")

--- a/bin/load-env
+++ b/bin/load-env
@@ -3,6 +3,7 @@
 require 'uri'
 require 'net/http'
 require 'openssl'
+require 'json'
 require_relative '../lib/jersey/vault_crypt'
 
 unless ARGV[0] && ARGV[1]
@@ -15,6 +16,8 @@ exit 1
 end
 
 blob = File.read(ARGV[0])
+# make sure its json
+JSON.parse(blob)
 uri  = URI.parse(ARGV[1])
 http = Net::HTTP.new(uri.host, uri.port)
 

--- a/bin/load-env
+++ b/bin/load-env
@@ -15,41 +15,42 @@ puts "
 exit 1
 end
 
+def error(response)
+  error = JSON.parse(response.body)['error']
+  puts "Error: #{error['message']}"
+end
+
+def req(http, request)
+  loop do
+    response = http.request(request)
+    case response.code.to_i
+    when 200
+      yield response
+      break
+    when 400..499
+      error(response)
+      break
+    else
+      error(response)
+      sleep 1
+    end
+  end
+end
+
 blob = File.read(ARGV[0])
 # make sure its json
 JSON.parse(blob)
 uri  = URI.parse(ARGV[1])
 http = Net::HTTP.new(uri.host, uri.port)
-
-request = Net::HTTP::Get.new("/pubkey")
-loop do
-  response = http.request(request)
-  if response.code.to_i == 200
-    @public_key = response.body
-    break
-  else
-    p response.body
-    sleep 1
-  end
-end
-
-@rsa_key = OpenSSL::PKey::RSA.new(@public_key.unpack("m0")[0])
-@cipher_json = VaultCrypt.encrypt(blob, [@rsa_key.public_key])
-
-request = Net::HTTP::Post.new("/msg/env")
-loop do
-  request.body = @cipher_json
-  response = http.request(request)
-  case response.code.to_i
-  when 200
+request = Net::HTTP::Get.new("/pubkey/env")
+req(http, request) do |response|
+  public_key = response.body
+  rsa_key = OpenSSL::PKey::RSA.new(public_key.unpack("m0")[0])
+  cipher_json = VaultCrypt.encrypt(blob, [rsa_key.public_key])
+  request = Net::HTTP::Post.new("/msg/env")
+  request.body = cipher_json
+  req(http, request) do |response|
     puts "ENV loaded"
-    break
-  when 400..499
-    error = JSON.parse(response.body)['error']
-    puts "Error: #{error['message']}"
-    break
-  else
-    p response.body
-    sleep 1
   end
 end
+

--- a/bin/load-env
+++ b/bin/load-env
@@ -1,0 +1,52 @@
+#! /usr/bin/env ruby
+
+require 'uri'
+require 'net/http'
+require 'openssl'
+require_relative '../lib/jersey/vault_crypt'
+
+unless ARGV[0] && ARGV[1]
+puts "
+  Usage:
+
+  load-env <file.json> <server>
+"
+exit 1
+end
+
+blob = File.read(ARGV[0])
+uri  = URI.parse(ARGV[1])
+http = Net::HTTP.new(uri.host, uri.port)
+
+request = Net::HTTP::Get.new("/pubkey")
+loop do
+  response = http.request(request)
+  if response.code.to_i == 200
+    @public_key = response.body
+    break
+  else
+    p response.body
+    sleep 1
+  end
+end
+
+@rsa_key = OpenSSL::PKey::RSA.new(@public_key.unpack("m0")[0])
+@cipher_json = VaultCrypt.encrypt(blob, [@rsa_key.public_key])
+
+request = Net::HTTP::Post.new("/msg/env")
+loop do
+  request.body = @cipher_json
+  response = http.request(request)
+  case response.code.to_i
+  when 200
+    puts "ENV loaded"
+    break
+  when 400..499
+    error = JSON.parse(response.body)['error']
+    puts "Error: #{error['message']}"
+    break
+  else
+    p response.body
+    sleep 1
+  end
+end

--- a/examples/eph_boot.rb
+++ b/examples/eph_boot.rb
@@ -1,8 +1,5 @@
 require 'jersey'
 Jersey.setup
 require 'jersey/eph_key_env'
-Jersey::API::EphKeyEnv.port = ENV['PORT'] || 8000
-Jersey::API::EphKeyEnv.standalone!
-Jersey::API::EphKeyEnv.quit_after_load!
-Jersey::API::EphKeyEnv.run!
+Jersey::API::EphKeyEnv.one_time_load!(8000)
 puts ENV["FOO"]

--- a/examples/eph_boot.rb
+++ b/examples/eph_boot.rb
@@ -1,5 +1,5 @@
 require 'jersey'
 Jersey.setup
 require 'jersey/eph_key_env'
-Jersey::API::EphKeyEnv.one_time_load!(8000)
+Jersey::API::EphKeyEnv.one_time_load!(port: 8000)
 puts ENV["FOO"]

--- a/examples/eph_boot.rb
+++ b/examples/eph_boot.rb
@@ -1,0 +1,8 @@
+require 'jersey'
+Jersey.setup
+require 'jersey/eph_key_env'
+Jersey::API::EphKeyEnv.port = ENV['PORT'] || 8000
+Jersey::API::EphKeyEnv.standalone!
+Jersey::API::EphKeyEnv.quit_after_load!
+Jersey::API::EphKeyEnv.run!
+puts ENV["FOO"]

--- a/examples/eph_key_env.ru
+++ b/examples/eph_key_env.ru
@@ -1,0 +1,16 @@
+require 'jersey'
+Jersey.setup
+require 'jersey/eph_key_env'
+
+class EnvAPI < Jersey::API::Base
+  use Jersey::API::EphKeyEnv
+
+  get '/env' do
+    Jersey.log(at: "env")
+    ENV["FOO"].to_s
+  end
+end
+
+run Rack::URLMap.new(
+  '/' => EnvAPI
+)

--- a/examples/eph_key_env.ru
+++ b/examples/eph_key_env.ru
@@ -11,6 +11,4 @@ class EnvAPI < Jersey::API::Base
   end
 end
 
-run Rack::URLMap.new(
-  '/' => EnvAPI
-)
+run EnvAPI

--- a/lib/jersey/base.rb
+++ b/lib/jersey/base.rb
@@ -8,25 +8,33 @@ require 'json'
 ::Sinatra.const_set(:NotFound, ::Jersey::HTTP::Errors::NotFound)
 
 module Jersey::API
-  class Base < Sinatra::Base
+  class Composable < Sinatra::Base
     include Jersey::HTTP::Errors
-
-    register Jersey::Extensions::RouteSignature
-
-    use Rack::Deflater
-    use Rack::ConditionalGet
-    use Rack::ETag
-
-    use Jersey::Middleware::RequestID
-    use Jersey::Middleware::RequestLogger
     use Jersey::Middleware::ErrorHandler
 
-    helpers Sinatra::JSON
-    helpers Jersey::Helpers::Log
-    helpers Jersey::Helpers::Success
+    def self.standalone!
+      register Jersey::Extensions::RouteSignature
 
-    set :dump_errors, false
-    set :raise_errors, true
-    set :show_exceptions, false
+      use Rack::Deflater
+      use Rack::ConditionalGet
+      use Rack::ETag
+
+      use Jersey::Middleware::RequestID
+      use Jersey::Middleware::RequestLogger
+      use Jersey::Middleware::ErrorHandler
+
+      helpers Sinatra::JSON
+      helpers Jersey::Helpers::Log
+      helpers Jersey::Helpers::Success
+
+      set :dump_errors, false
+      set :raise_errors, true
+      set :show_exceptions, false
+      self
+    end
   end
+
+  class Base < Composable
+  end
+  Base.standalone!
 end

--- a/lib/jersey/eph_key_env.rb
+++ b/lib/jersey/eph_key_env.rb
@@ -34,6 +34,9 @@ module Jersey::API
           ENV[key] = value
         end
         @@loaded = true
+        if @@quit_after_load
+          self.class.quit!
+        end
         'OK'
       end
     end
@@ -42,6 +45,10 @@ module Jersey::API
       def self.reset!
         @@loaded = @@rsa_key = @@public_key  = false
       end
+    end
+
+    def self.quit_after_load!
+      @@quit_after_load = true
     end
 
     helpers do

--- a/lib/jersey/eph_key_env.rb
+++ b/lib/jersey/eph_key_env.rb
@@ -4,11 +4,15 @@ require 'jersey/vault_crypt'
 module Jersey::API
   # Ephemeral-Key P2P Msg to enable
   # secure ENV loading
-  class EphKeyEnv < Jersey::API::Base
+  class EphKeyEnv < Composable
     @@loaded = false
 
-    get '/pubkey' do
-      public_key
+    get '/pubkey/env' do
+      if @@loaded
+        raise BadRequest, "ENV already loaded"
+      else
+        public_key
+      end
     end
 
     post '/msg/env' do
@@ -31,6 +35,12 @@ module Jersey::API
         end
         @@loaded = true
         'OK'
+      end
+    end
+
+    if Config.test?
+      def self.reset!
+        @@loaded = @@rsa_key = @@public_key  = false
       end
     end
 

--- a/lib/jersey/eph_key_env.rb
+++ b/lib/jersey/eph_key_env.rb
@@ -1,0 +1,47 @@
+require 'json'
+require 'jersey/vault_crypt'
+
+module Jersey::API
+  # Ephemeral-Key P2P Msg to enable
+  # secure ENV loading
+  class EphKeyEnv < Jersey::API::Base
+    @@loaded = false
+
+    get '/pubkey' do
+      public_key
+    end
+
+    post '/msg/env' do
+      if @@loaded
+        raise BadRequest, "ENV already loaded"
+      else
+        # attempt decrypt and JSON parse
+        begin
+          request.body.rewind
+          data = request.body.read
+          naked_data = VaultCrypt.decrypt(data, rsa_key)
+          env_data = JSON.parse(naked_data)
+        rescue => e
+          raise BadRequest.new(e)
+        end
+
+        # load env data
+        env_data.each do |key, value|
+          ENV[key] = value
+        end
+        @@loaded = true
+        'OK'
+      end
+    end
+
+    helpers do
+      def rsa_key
+        @@rsa_key ||= OpenSSL::PKey::RSA.generate(2048)
+      end
+
+      def public_key
+        @@public_key ||= [rsa_key.public_key.to_der].pack("m0")
+      end
+    end
+  end
+end

--- a/lib/jersey/eph_key_env.rb
+++ b/lib/jersey/eph_key_env.rb
@@ -51,6 +51,14 @@ module Jersey::API
       @@quit_after_load = true
     end
 
+    def self.one_time_load!(bind: '0.0.0.0', port: 80)
+      self.bind = bind
+      self.port = port
+      self.standalone!
+      self.quit_after_load!
+      self.run!
+    end
+
     helpers do
       def rsa_key
         @@rsa_key ||= OpenSSL::PKey::RSA.generate(2048)

--- a/lib/jersey/middleware/error_handler.rb
+++ b/lib/jersey/middleware/error_handler.rb
@@ -32,6 +32,8 @@ module Jersey::Middleware
           body[:error][:backtrace] = e.backtrace
         end
 
+        Jersey.log(e)
+
         [status, headers, [body.to_json]]
       end
     end

--- a/lib/jersey/vault_crypt.rb
+++ b/lib/jersey/vault_crypt.rb
@@ -1,0 +1,48 @@
+require 'securerandom'
+require 'openssl'
+require 'digest'
+require 'json'
+
+module VaultCrypt
+  CIPHER_NAME = "AES-256-CBC"
+  IV_LENGTH = 16
+
+  def aes_encrypt(data)
+    cipher = OpenSSL::Cipher.new(CIPHER_NAME).encrypt
+    cipher.iv = iv = SecureRandom.random_bytes(IV_LENGTH)
+    cipher.key = key = cipher.random_key
+    encrypted = cipher.update(data) + cipher.final
+    [iv, key, encrypted]
+  end
+
+  def aes_decrypt(encrypted_data, iv, key)
+    cipher = OpenSSL::Cipher.new(CIPHER_NAME).decrypt
+    cipher.iv  = iv
+    cipher.key = key
+    cipher.update(encrypted_data) + cipher.final
+  end
+
+  def encrypt(data, public_keys)
+    aes_iv, aes_key, aes_blob = aes_encrypt(data)
+    aes_blob_hash = Digest::SHA256.digest(aes_blob)
+    key_blob = [aes_iv, aes_key, aes_blob_hash].join
+
+    recipients = {}
+    public_keys.each{|public_key| recipients[ [public_key.to_der].pack("m0") ] = [public_key.public_encrypt(key_blob)].pack("m0") }
+
+    JSON.pretty_generate({ blob: [aes_blob].pack("m0"), recipients: recipients })
+  end
+
+  def decrypt(json, privkey)
+    json = JSON.parse(json)
+    key_blob = json['recipients'].find{|k,v| k == [privkey.public_key.to_der].pack("m0") }.last.unpack("m0")[0] rescue (return nil)
+    aes_iv, aes_key, aes_blob_hash = privkey.private_decrypt(key_blob).unpack("a16a32a32") rescue (return nil)
+
+    blob = json['blob'].unpack("m0")[0]
+    if Digest::SHA256.digest(blob) == aes_blob_hash
+      aes_decrypt(blob, aes_iv, aes_key)
+    end
+  end
+
+  extend self
+end

--- a/test/eph_key_env_test.rb
+++ b/test/eph_key_env_test.rb
@@ -36,6 +36,7 @@ class SuccessTest < ApiTest
 
     get '/foo'
     assert_equal('bar', last_response.body)
+    ENV.delete('FOO')
   end
 
   def test_load_env_with_bad_pubkey

--- a/test/eph_key_env_test.rb
+++ b/test/eph_key_env_test.rb
@@ -10,32 +10,46 @@ class SuccessTest < ApiTest
     end
   end
 
+  def setup
+    super
+    Jersey::API::EphKeyEnv.reset!
+  end
+
   def test_GET_pubkey_returns_one_pubkey
-    get '/pubkey'
+    get '/pubkey/env'
+    assert_equal(200, last_response.status)
     pubkey = last_response.body
     OpenSSL::PKey::RSA.new(pubkey.unpack("m0")[0])
 
-    get '/pubkey'
+    get '/pubkey/env'
+    assert_equal(200, last_response.status)
     pubkey2 = last_response.body
     assert_equal(pubkey, pubkey2)
   end
 
   def test_load_env_with_vault
-    get '/pubkey'
+    # generate message
+    get '/pubkey/env'
     pubkey  = last_response.body
     rsa_key = OpenSSL::PKey::RSA.new(pubkey.unpack("m0")[0])
     blob = JSON.generate("FOO" => "bar")
     cipher_json = VaultCrypt.encrypt(blob, [rsa_key.public_key])
 
+    # loading secret works
     get '/foo'
     assert_equal('', last_response.body)
-
     post '/msg/env', cipher_json
     assert_equal(200, last_response.status)
-    assert_equal('OK', last_response.body)
-
     get '/foo'
     assert_equal('bar', last_response.body)
+
+    # no longer accepting requests
+    get '/pubkey/env'
+    assert_equal(400, last_response.status)
+    post '/msg/env', cipher_json
+    assert_equal(400, last_response.status)
+
+    # cleanup
     ENV.delete('FOO')
   end
 

--- a/test/eph_key_env_test.rb
+++ b/test/eph_key_env_test.rb
@@ -1,0 +1,49 @@
+require_relative 'helper'
+require 'jersey/eph_key_env'
+
+class SuccessTest < ApiTest
+  class App < Jersey::API::Base
+    use Jersey::API::EphKeyEnv
+
+    get '/foo' do
+      ENV['FOO']
+    end
+  end
+
+  def test_GET_pubkey_returns_one_pubkey
+    get '/pubkey'
+    pubkey = last_response.body
+    OpenSSL::PKey::RSA.new(pubkey.unpack("m0")[0])
+
+    get '/pubkey'
+    pubkey2 = last_response.body
+    assert_equal(pubkey, pubkey2)
+  end
+
+  def test_load_env_with_vault
+    get '/pubkey'
+    pubkey  = last_response.body
+    rsa_key = OpenSSL::PKey::RSA.new(pubkey.unpack("m0")[0])
+    blob = JSON.generate("FOO" => "bar")
+    cipher_json = VaultCrypt.encrypt(blob, [rsa_key.public_key])
+
+    get '/foo'
+    assert_equal('', last_response.body)
+
+    post '/msg/env', cipher_json
+    assert_equal(200, last_response.status)
+    assert_equal('OK', last_response.body)
+
+    get '/foo'
+    assert_equal('bar', last_response.body)
+  end
+
+  def test_load_env_with_bad_pubkey
+    rsa_key = OpenSSL::PKey::RSA.generate(1024)
+    blob = JSON.generate("FOO" => "bar")
+    cipher_json = VaultCrypt.encrypt(blob, [rsa_key.public_key])
+
+    post '/msg/env', cipher_json
+    assert_equal(400, last_response.status)
+  end
+end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -49,10 +49,10 @@ class ErrorsTest < ApiTest
     Jersey.logger.stream = StringIO.new
     get '/test-500'
     loglines = logs.lines
-    assert_equal(2, loglines.size)
-    logdata = Logfmt.parse(loglines[0])
+    assert(loglines.size > 2)
+    logdata = Logfmt.parse(loglines.first)
     assert(logdata['at'], 'started')
-    logdata = Logfmt.parse(loglines[1])
+    logdata = Logfmt.parse(loglines.last)
     assert(logdata['at'], 'finished')
     assert(logdata['status'], '500')
   end


### PR DESCRIPTION
Creates mini-sinatra service that must be mounted in-memory
for security (so cannot run elsewhere).

Generates an ephemeral RSA key that is used to load the
app environment (enoded as a simple json hash).

Has tests, examples, and provides a command line.
